### PR TITLE
Fix template module import for Django 1.8.x.

### DIFF
--- a/adv_cache_tag/tag.py
+++ b/adv_cache_tag/tag.py
@@ -8,7 +8,12 @@ try:
 except:
     import pickle
 
-from django import template
+try:
+    from django.template import BLOCK_TAG_START  # Before django 1.8.x
+    from django import template
+except ImportError:
+    from django.template import base as template
+
 from django.template.base import libraries
 from django.conf import settings
 from django.utils.http import urlquote


### PR DESCRIPTION
Template system was refactored In Django 1.8.x. So some imports have been broken. 

```python
Traceback (most recent call last):
  ...
  File "/venv/lib/python2.7/site-packages/django/shortcuts.py", line 67, in render
    template_name, context, request=request, using=using)
  File "/venv/lib/python2.7/site-packages/django/template/loader.py", line 98, in render_to_string
    template = get_template(template_name, using=using)
  File "/venv/lib/python2.7/site-packages/django/template/loader.py", line 35, in get_template
    return engine.get_template(template_name, dirs)
  File "/venv/lib/python2.7/site-packages/django/template/backends/django.py", line 30, in get_template
    return Template(self.engine.get_template(template_name, dirs))
  File "/venv/lib/python2.7/site-packages/django/template/engine.py", line 167, in get_template
    template, origin = self.find_template(template_name, dirs)
  File "/venv/lib/python2.7/site-packages/django/template/engine.py", line 141, in find_template
    source, display_name = loader(name, dirs)
  File "/venv/lib/python2.7/site-packages/django/template/loaders/base.py", line 13, in __call__
    return self.load_template(template_name, template_dirs)
  File "/venv/lib/python2.7/site-packages/django/template/loaders/base.py", line 23, in load_template
    template = Template(source, origin, template_name, self.engine)
  File "/venv/lib/python2.7/site-packages/django/template/base.py", line 190, in __init__
    self.nodelist = engine.compile_string(template_string, origin)
  File "/venv/lib/python2.7/site-packages/django/template/engine.py", line 261, in compile_string
    return parser.parse()
  File "/venv/lib/python2.7/site-packages/django/template/base.py", line 341, in parse
    compiled_result = compile_func(self, token)
  File "/venv/lib/python2.7/site-packages/django/template/defaulttags.py", line 1159, in load
    lib = get_library(taglib)
  File "/venv/lib/python2.7/site-packages/django/template/base.py", line 1392, in get_library
    lib = import_library(taglib_module)
  File "/venv/lib/python2.7/site-packages/django/template/base.py", line 1331, in import_library
    mod = import_module(taglib_module)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/venv/src/adv-cache-tag/adv_cache_tag/templatetags/adv_cache.py", line 4, in <module>
    from adv_cache_tag.tag import CacheTag
  File "/venv/src/adv-cache-tag/adv_cache_tag/tag.py", line 36, in <module>
    class CacheTag(object):
  File "/venv/src/adv-cache-tag/adv_cache_tag/tag.py", line 78, in CacheTag
    RAW_TOKEN_START = template.BLOCK_TAG_START + RAW_TOKEN + template.BLOCK_TAG_END
AttributeError: 'module' object has no attribute 'BLOCK_TAG_START'
```