### PR TITLE
Allow passing the cache backend in the templatetab

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -511,6 +511,15 @@ even more, you can override the ``cache_set`` and ``cache_get`` methods
 of the ``CacheTag`` class if you don't want to use the default ``set``
 and ``get`` methods of the cache backend object.
 
+Note that we also support the django way of changing the cache backend in the template-tag, using
+the ``using`` argument, to be set at the last parameter (without any space between `using` and the
+name of the cache backend).
+
+.. code:: django
+
+    {% cache 0 myobj_main_template obj.pk obj.date_last_updated using=foo %}
+
+
 Change the cache key
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/adv_cache_tag/tag.py
+++ b/adv_cache_tag/tag.py
@@ -36,6 +36,10 @@ class Node(template.Node):
         self.expire_time = template.Variable(expire_time)
         self.fragment_name = template.Variable(fragment_name)
 
+        self.cache_backend = None
+        if vary_on and vary_on[-1].startswith('using='):
+            self.cache_backend = vary_on.pop()[len('using='):]
+
         self.version = None
         if self._cachetag_class_.options.versioning:
             try:
@@ -304,7 +308,7 @@ class CacheTag(object):
         every object with a `get` and a `set` method (or not, if `cache_get`
         and `cache_set` methods are overridden)
         """
-        return get_cache(self.options.cache_backend)
+        return get_cache(self.node.cache_backend or self.options.cache_backend)
 
     def cache_get(self):
         """


### PR DESCRIPTION
It's possible by passing `using=...` as the last parameter of the
templatetag, as it's done in Django for the default `cache` tag.