### PR TITLE
Support for python 3 (only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ cache:
     - $HOME/.cache/pip
 
 python:
- - "2.6"
- - "2.7"
+ - "3.2"
+ - "3.3"
+ - "3.4"
+ - "3.5"
 
 env:
- - DJANGO="Django>=1.3,<1.4"
- - DJANGO="Django>=1.4,<1.5"
  - DJANGO="Django>=1.5,<1.6"
  - DJANGO="Django>=1.6,<1.7"
  - DJANGO="Django>=1.7,<1.8"
@@ -26,10 +26,20 @@ script: "./runtests.sh"
 matrix:
   exclude:
 
-    - python: "2.6"
+    - python: "3.5"
+      env: DJANGO="Django>=1.5,<1.6"
+    - python: "3.5"
+      env: DJANGO="Django>=1.6,<1.7"
+    - python: "3.5"
       env: DJANGO="Django>=1.7,<1.8"
-    - python: "2.6"
-      env: DJANGO="Django>=1.8,<1.8.99"
-    - python: "2.6"
+
+    - python: "3.4"
+      env: DJANGO="Django>=1.5,<1.6"
+    - python: "3.4"
+      env: DJANGO="Django>=1.6,<1.7"
+
+    - python: "3.3"
       env: DJANGO="--pre Django<1.10"
 
+    - python: "3.2"
+      env: DJANGO="--pre Django<1.10"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Release *v1.0* - ``2015-10-29``
+-------------------------------
+* WARNING: internal version changed, all existing cached fragment will be reset
+* Remove support for python 2
+* Remove support for django < 1.5
+
 Release *v0.2.1* - ``2015-10-29``
 ---------------------------------
 * Mark release 0.2.1 as only compatible with python 2

--- a/README.md
+++ b/README.md
@@ -50,10 +50,19 @@ Installation
 
 `django-adv-cache-tag` is available on PyPI:
 
-    pip install django-adv-cache-tag==0.2.1
+    pip install django-adv-cache-tag
 
-You must specify the version as the last one available (`>=1.0`) only
-support python 3.
+Starting at version `1.0`, we only support python 3.
+
+**If you upgrade from version \< 1, note that the internal version
+number has changed, so all cache will be reset.**
+
+If you want python 2 support, you must install by passing the version :
+
+    pip install 'django-adv-cache-tag<=1.0'
+
+(and check the relevant documentation for the correct tag on the github
+repository)
 
 Or you can find it on Github:
 <https://github.com/twidi/django-adv-cache-tag>
@@ -839,12 +848,14 @@ Supported versions
 ------------------
 
   Django version   | Python version
-  ---------------- | ----------------
-  1.4, 1.5, 1.6    | 2.6, 2.7
-  1.7, 1.8, 1.9    | 2.7
+  ---------------- | --------------------
+  1.5, 1.6         | 3.2, 3.3
+  1.7              | 3.2, 3.3, 3.4
+  1.8              | 3.2, 3.3, 3.4, 3.5
+  1.9              | 3.4, 3.5
 
-Support for Python 3 to come in version 1.0. Then, the support for
-Python 2 will be dropped.
+Support for Python 2 is dropped since version 1 of
+`django-adv-cache-tag`
 
 [![Bitdeli
 Badge](https://d2weczhvl823v0.cloudfront.net/twidi/django-adv-cache-tag/trend.png)](https://bitdeli.com/free)

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,18 @@ Installation
 
 ``django-adv-cache-tag`` is available on PyPI::
 
-    pip install django-adv-cache-tag==0.2.1
+    pip install django-adv-cache-tag
 
-You must specify the version as the last one available (``>=1.0``) only support python 3.
+Starting at version ``1.0``, we only support python 3.
+
+**If you upgrade from version < 1, note that the internal version number has changed, so all
+cache will be reset.**
+
+If you want python 2 support, you must install by passing the version ::
+
+    pip install 'django-adv-cache-tag<=1.0'
+
+(and check the relevant documentation for the correct tag on the github repository)
 
 Or you can find it on Github:
 https://github.com/twidi/django-adv-cache-tag
@@ -877,11 +886,13 @@ Supported versions
 ============== ==============
 Django version Python version
 ============== ==============
-1.4, 1.5, 1.6  2.6, 2.7
-1.7, 1.8, 1.9  2.7
+1.5, 1.6       3.2, 3.3
+1.7            3.2, 3.3, 3.4
+1.8            3.2, 3.3, 3.4, 3.5
+1.9            3.4, 3.5
 ============== ==============
 
-Support for Python 3 to come in version 1.0. Then, the support for Python 2 will be dropped.
+Support for Python 2 is dropped since version 1 of ``django-adv-cache-tag``
 
 
 |Bitdeli Badge|

--- a/adv_cache_tag/__init__.py
+++ b/adv_cache_tag/__init__.py
@@ -1,5 +1,5 @@
 """An advanced template tag for caching in django: versioning, compress, partial caching, easy inheritance"""
-VERSION = (0, 2, 1)
+VERSION = (1, 0, 0)
 
 __author__ = 'Stephane "Twidi" Angel'
 __contact__ = "s.angel@twidid.com"

--- a/adv_cache_tag/compat.py
+++ b/adv_cache_tag/compat.py
@@ -1,7 +1,3 @@
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 try:
     from django.core.cache import caches

--- a/adv_cache_tag/tests/compat.py
+++ b/adv_cache_tag/tests/compat.py
@@ -1,71 +1,6 @@
 from django import VERSION
-from django.conf import settings
 from django.test import TestCase
 
-from adv_cache_tag.compat import template
-
-try:
-    from django.test.utils import override_settings
-except ImportError:
-    # Django < 1.4
-    from django.conf import UserSettingsHolder
-    from django.utils.functional import wraps
-
-    class override_settings(object):
-        """
-        Acts as either a decorator, or a context manager. If it's a decorator it
-        takes a function and returns a wrapped function. If it's a contextmanager
-        it's used with the ``with`` statement. In either event entering/exiting
-        are called before and after, respectively, the function/block is executed.
-        """
-        def __init__(self, **kwargs):
-            self.options = kwargs
-
-        def __enter__(self):
-            self.enable()
-
-        def __exit__(self, exc_type, exc_value, traceback):
-            self.disable()
-
-        def __call__(self, test_func):
-            from django.test import TransactionTestCase
-            if isinstance(test_func, type):
-                if not issubclass(test_func, TransactionTestCase):
-                    raise Exception(
-                        "Only subclasses of Django TransactionTestCase can be decorated "
-                        "with override_settings")
-                original_pre_setup = test_func._pre_setup
-                original_post_teardown = test_func._post_teardown
-
-                def _pre_setup(innerself):
-                    self.enable()
-                    original_pre_setup(innerself)
-
-                def _post_teardown(innerself):
-                    original_post_teardown(innerself)
-                    self.disable()
-                test_func._pre_setup = _pre_setup
-                test_func._post_teardown = _post_teardown
-                return test_func
-            else:
-                @wraps(test_func)
-                def inner(*args, **kwargs):
-                    with self:
-                        return test_func(*args, **kwargs)
-            return inner
-
-        def enable(self):
-            override = UserSettingsHolder(settings._wrapped)
-            for key, new_value in self.options.items():
-                setattr(override, key, new_value)
-            self.wrapped = settings._wrapped
-            settings._wrapped = override
-
-        def disable(self):
-            settings._wrapped = self.wrapped
-            del self.wrapped
-            for key in self.options:
-                new_value = getattr(settings, key, None)
 
 if VERSION < (1, 7):
     from adv_cache_tag.compat import get_cache
@@ -78,17 +13,3 @@ if VERSION < (1, 7):
             # `override_settings`
             from django.core import cache
             cache.cache = get_cache('default')
-
-
-try:
-    from django.utils.safestring import SafeText
-except ImportError:
-    # Django < 1.4
-    from django.utils.safestring import SafeUnicode as SafeText
-
-
-if VERSION < (1, 4):
-    # In Django 1.3, original errors where catched and a ``TemplateSyntaxError`` was raised
-    ValueErrorInRender = template.TemplateSyntaxError
-else:
-    ValueErrorInRender = ValueError

--- a/adv_cache_tag/tests/testproject/adv_cache_test_app/templatetags/adv_cache_test.py
+++ b/adv_cache_tag/tests/testproject/adv_cache_test_app/templatetags/adv_cache_test.py
@@ -23,7 +23,7 @@ class TestCacheTag(CacheTag):
         """ Check validity of tokens and return them as ready to be passed to the Node class """
         if len(tokens) < 4:
             raise template.TemplateSyntaxError(
-                u"'%r' tag requires at least 3 arguments." % tokens[0])
+                "'%r' tag requires at least 3 arguments." % tokens[0])
         return tokens[1], tokens[2], tokens[3], tokens[4:]
 
     def prepare_params(self):

--- a/adv_cache_tag/tests/testproject/settings.py
+++ b/adv_cache_tag/tests/testproject/settings.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import os.path
 
 DEBUG = True

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ from setuptools import setup, find_packages
 
 import adv_cache_tag
 
-if sys.version_info >= (3,):
-    sys.stderr.write('Fatal error: django-adv-cache-tag %s only works with python 2. '
-                     'Use version >=1.0 for python 3.\n' % adv_cache_tag.__version__)
+if sys.version_info < (3,):
+    sys.stderr.write('Fatal error: django-adv-cache-tag %s only works with python 3. '
+                     'Use version <1.0 for python 2.\n' % adv_cache_tag.__version__)
     sys.exit(1)
 
 long_description = codecs.open('README.rst', "r", "utf-8").read()
@@ -41,12 +41,13 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2 :: Only",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.2",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Framework :: Django",
-        "Framework :: Django :: 1.4",
         "Framework :: Django :: 1.5",
         "Framework :: Django :: 1.6",
         "Framework :: Django :: 1.7",


### PR DESCRIPTION
Starting from version 1 we support only python 3.

As django < 1.5 don't support python 3, we don't support django 1.3 and
1.4 anymore.