### PR TITLE
Add a way to chose the compression level

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+To be released
+--------------
+* Fix failure when using ``internal_version``
+* Add a way to chose compression level
+
 Release *v1.1.2* - ``2018-11-27``
 ---------------------------------
 * Add support for Django 2.1

--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ own version:
 `ADV_CACHE_COMPRESS`, default to `False`, to activate the compression
 via `zlib`
 
+`ADV_CACHE_COMPRESS_LEVEL`, default to `-1`, to set le compression level
+for `zlib` (actually the default is `zlib.Z_DEFAULT_COMPRESSION`, which is
+`-1`, that will be in fact `6` as the actual default defined in `zlib`)
+
 `ADV_CACHE_COMPRESS_SPACES`, default to `False`, to activate the
 reduction of blank characters.
 
@@ -728,6 +732,9 @@ object)
     (`versioning` in the `Meta` class)
 -   `ADV_CACHE_COMPRESS` to activate compression, default to `False`
     (`compress` in the `Meta` class)
+-   `ADV_CACHE_COMPRESS_LEVEL` to set the compression level (from `1` (min
+    compression) to `9` (max compression), default to `-1` (equivalent to
+    `6`) (`compress_level` in the `Meta` class)
 -   `ADV_CACHE_COMPRESS_SPACES` to activate spaces compression, default
     to `False` (`compress_spaces` in the `Meta` class)
 -   `ADV_CACHE_INCLUDE_PK` to activate the "primary key" feature,

--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,10 @@ Settings
 ``ADV_CACHE_COMPRESS``, default to ``False``, to activate the
 compression via ``zlib``
 
+``ADV_CACHE_COMPRESS_LEVEL``, default to ``-1``, to set le compression level
+for ``zlib`` (actually the default is ``zlib.Z_DEFAULT_COMPRESSION``, which is
+``-1``, that will be in fact ``6`` as the actual default defined in ``zlib``)
+
 ``ADV_CACHE_COMPRESS_SPACES``, default to ``False``, to activate the
 reduction of blank characters.
 
@@ -763,6 +767,9 @@ list, with descriptions, default values, and corresponding fields in the
    (``versioning`` in the ``Meta`` class)
 -  ``ADV_CACHE_COMPRESS`` to activate compression, default to ``False``
    (``compress`` in the ``Meta`` class)
+-   ``ADV_CACHE_COMPRESS_LEVEL`` to set the compression level (from ``1`` (min
+    compression) to ``9`` (max compression), default to ``-1`` (equivalent to
+    ``6``) (``compress_level`` in the ``Meta`` class)
 -  ``ADV_CACHE_COMPRESS_SPACES`` to activate spaces compression, default
    to ``False`` (``compress_spaces`` in the ``Meta`` class)
 -  ``ADV_CACHE_INCLUDE_PK`` to activate the "primary key" feature,

--- a/adv_cache_tag/tag.py
+++ b/adv_cache_tag/tag.py
@@ -112,6 +112,7 @@ class CacheTag(object, metaclass=CacheTagMetaClass):
 
         * ADV_CACHE_VERSIONING
         * ADV_CACHE_COMPRESS
+        * ADV_CACHE_COMPRESS_LEVEL
         * ADV_CACHE_COMPRESS_SPACES
         * ADV_CACHE_INCLUDE_PK
         * ADV_CACHE_BACKEND
@@ -169,6 +170,7 @@ class CacheTag(object, metaclass=CacheTagMetaClass):
 
         # If the content will be compressed before caching
         compress = getattr(settings, 'ADV_CACHE_COMPRESS', False)
+        compress_level = getattr(settings, 'ADV_CACHE_COMPRESS_LEVEL', zlib.Z_DEFAULT_COMPRESSION)
 
         # If many spaces/blanks will be converted into one
         compress_spaces = getattr(settings, 'ADV_CACHE_COMPRESS_SPACES', False)
@@ -416,7 +418,7 @@ class CacheTag(object, metaclass=CacheTagMetaClass):
         """
         Encode (compress...) the html to the data to be cached
         """
-        return zlib.compress(pickle.dumps(self.content))
+        return zlib.compress(pickle.dumps(self.content), self.options.compress_level)
 
     def render_node(self):
         """


### PR DESCRIPTION
Settings: `ADV_CACHE_COMPRESS_LEVEL`
Meta option: `compress_level`

Default to `-1` (in fact `zlib.Z_DEFAULT_COMPRESSION`) which will be in
fact `6` (as defined in zlib documentation)