### PR TITLE
Support for non-standard TEMPLATES

### DIFF
--- a/adv_cache_tag/compat.py
+++ b/adv_cache_tag/compat.py
@@ -22,7 +22,7 @@ def get_template_libraries():
         from django.template.base import libraries
     except ImportError:
         # Django >= 1.9
-        from django.template import engines
-        libraries = engines['django'].engine.template_libraries
+        from django.template import Engine
+        libraries = Engine.get_default().template_libraries
 
     return libraries

--- a/adv_cache_tag/tag.py
+++ b/adv_cache_tag/tag.py
@@ -9,7 +9,7 @@ import zlib
 from django import VERSION as django_version
 from django.conf import settings
 from django.utils.encoding import smart_str, force_bytes
-from urlparse import quote
+from urllib.parse import quote
 
 from .compat import get_cache, get_template_libraries, template
 

--- a/adv_cache_tag/tag.py
+++ b/adv_cache_tag/tag.py
@@ -9,7 +9,7 @@ import zlib
 from django import VERSION as django_version
 from django.conf import settings
 from django.utils.encoding import smart_str, force_bytes
-from django.utils.http import urlquote
+from urlparse import quote
 
 from .compat import get_cache, get_template_libraries, template
 
@@ -301,7 +301,7 @@ class CacheTag(object, metaclass=CacheTagMetaClass):
         Take all the arguments passed after the fragment name and return a
         hashed version which will be used in the cache key
         """
-        return hashlib.md5(force_bytes(':'.join([urlquote(force_bytes(var)) for var in self.vary_on]))).hexdigest()
+        return hashlib.md5(force_bytes(':'.join([quote(force_bytes(var)) for var in self.vary_on]))).hexdigest()
 
     def get_pk(self):
         """


### PR DESCRIPTION
My setup has no `TEMPLATES["django"]` engine, which caused an "Invalid Backend" error. This small change fixes that.